### PR TITLE
Update scala logging to 3.1.0

### DIFF
--- a/core/src/main/scala/com/rethinkscala/net/Connection.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Connection.scala
@@ -13,7 +13,7 @@ import com.rethinkscala.ast._
 import com.rethinkscala.net.Translate._
 import com.rethinkscala.reflect.Reflector
 import com.rethinkscala.utils.{ConnectionWithId, ConnectionFactory, SimpleConnectionPool}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.jboss.netty.bootstrap.ClientBootstrap
 import org.jboss.netty.buffer.ChannelBuffers._
 import org.jboss.netty.buffer.{ChannelBuffer, HeapChannelBufferFactory}

--- a/core/src/main/scala/com/rethinkscala/net/Decoder.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Decoder.scala
@@ -1,7 +1,7 @@
 package com.rethinkscala.net
 
 import com.rethinkscala.reflect.Reflector
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.jboss.netty.buffer.ChannelBuffer
 import org.jboss.netty.channel.{Channel, ChannelHandlerContext}
 import org.jboss.netty.handler.codec.frame.FrameDecoder

--- a/core/src/main/scala/com/rethinkscala/net/Handler.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Handler.scala
@@ -1,6 +1,6 @@
 package com.rethinkscala.net
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.jboss.netty.channel.{ChannelHandlerContext, ExceptionEvent, MessageEvent, SimpleChannelUpstreamHandler}
 import org.jboss.netty.handler.queue.BufferedWriteHandler
 import ql2.Ql2.Response

--- a/core/src/main/scala/com/rethinkscala/net/Token.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Token.scala
@@ -8,7 +8,7 @@ import com.rethinkscala.{ResultExtractor,Term,Profile,Document,ConvertFrom}
 import com.rethinkscala.ast.Datum
 import com.rethinkscala.net.Translate._
 import com.rethinkscala.reflect.Reflector
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import ql2.Ql2.Response
 import ql2.Ql2.Response.ResponseType
 

--- a/core/src/main/scala/com/rethinkscala/net/Translate.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Translate.scala
@@ -4,7 +4,7 @@ package com.rethinkscala.net
 import com.rethinkscala.reflect.Reflector
 import com.rethinkscala.{JsonDocument, GeneratesKeys, Term, Document}
 import com.rethinkscala.ast.{After, WithLifecycle}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 
 object Translate {
   def translate[Out](implicit ct: Manifest[Out]): Translate[Out] = new BaseTranslate[Out] {}

--- a/core/src/main/scala/com/rethinkscala/net/Version.scala
+++ b/core/src/main/scala/com/rethinkscala/net/Version.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.{Executors, TimeUnit}
 import com.rethinkscala.ast._
 import com.rethinkscala.reflect.Reflector
 import com.rethinkscala.{ResultExtractor, Term, TermAssocPair}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.jboss.netty.buffer.ChannelBuffer
 import org.jboss.netty.buffer.ChannelBuffers._
 import org.jboss.netty.channel.Channel

--- a/core/src/main/scala/com/rethinkscala/net/VersionHandler.scala
+++ b/core/src/main/scala/com/rethinkscala/net/VersionHandler.scala
@@ -6,8 +6,7 @@ import java.util.concurrent.atomic.AtomicLong
 import com.google.common.cache.{CacheBuilder, Cache}
 import com.rethinkscala.{ResultExtractor, Term}
 import com.rethinkscala.ast.ProduceSequence
-import com.typesafe.scalalogging.Logging
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import ql2.Ql2.Response
 import ql2.Ql2.Response.ResponseType
 import ql2.Ql2.Response.ResponseType._

--- a/core/src/main/scala/com/rethinkscala/utils/ConnectionPool.scala
+++ b/core/src/main/scala/com/rethinkscala/utils/ConnectionPool.scala
@@ -3,7 +3,7 @@ package com.rethinkscala.utils
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.TimeUnit
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration

--- a/project/RethinkdbBuild.scala
+++ b/project/RethinkdbBuild.scala
@@ -110,7 +110,7 @@ object RethinkdbBuild extends Build {
 
         "org.scalatest" %% "scalatest" % "2.1.3" % "test",
         //"com.typesafe" %% "scalalogging-slf4j" % "1.0.1",
-        "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.0.3",
+        "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
         "org.slf4j" % "slf4j-log4j12" % "1.7.6",
 
         "io.netty" % "netty" % "3.9.3.Final",


### PR DESCRIPTION
Old version : 
"com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.0.3"
New version : 
"com.typesafe.scala-logging" %% "scala-logging" % "3.1.0"

The old version cause compatibility issues with library that use the last version of scala-logging.