### PR TITLE
Fix minor syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ import com.rethinkscala.Blocking._ // for blocking api
 implicit val blockingConnection = Blocking(Version2)
 import com.rethinkscala.Async._ // for async api
 implicit val asyncConnection = Async(Version2)
-``
+```
+
 Examples
+
 ```scala
 
 scala> r.table("marvel").map(hero=> hero \ "combatPower" + hero \ "combatPower" * 2)


### PR DESCRIPTION
Spotted a minor syntax error in a code fenced block.